### PR TITLE
Keep items in the head after the initial render

### DIFF
--- a/src/worker/handlers/initial.js
+++ b/src/worker/handlers/initial.js
@@ -3,19 +3,25 @@ var Location = require("micro-location");
 
 module.exports = function(data){
 	route.location = Location.parse(data.location);
-
 	var docEl = document.documentElement;
+
+	// Keep the contents inside the <head> because they might have
+	// been set as part of the page load. An example is <style>
+	// tags added by the css plugin.
+	var resetContent = preserveHeadContent(docEl);
+
 	docEl.innerHTML = data.content;
 
-	setIfPresent(document, "body");
-	setIfPresent(document, "head");
+	setIfPresent(docEl, "body");
+	setIfPresent(docEl, "head");
+
+	return resetContent;
 };
 
-function setIfPresent(document, nodeName){
-	var docEl = document.documentElement;
+function getBaseElement(docEl, nodeName){
 	var upperCase = nodeName.toUpperCase();
 
-	var node = (function(){
+	return (function(){
 		var child = docEl.firstChild;
 		while(child) {
 			if(child.nodeName === upperCase) {
@@ -25,8 +31,38 @@ function setIfPresent(document, nodeName){
 		}
 		return null;
 	})();
+}
+
+/**
+ * Set the document.body and document.head properties.
+ */
+function setIfPresent(docEl, nodeName){
+	var node = getBaseElement(docEl, nodeName);
 
 	if(node) {
 		document[nodeName] = node;
 	}
+}
+
+function preserveHeadContent(docEl){
+	var head = getBaseElement(docEl, "head");
+	var preserveTags = { "STYLE": true, "LINK": true };
+
+	var elements = [];
+	if(head) {
+		var cur = head.firstChild;
+		while(cur) {
+			if(preserveTags[cur.nodeName]) {
+				elements.push(cur);
+			}
+			cur = cur.nextSibling;
+		}
+	}
+
+	return function(){
+		var head = getBaseElement(docEl, "head");
+		elements.forEach(function(element){
+			head.appendChild(element);
+		});
+	};
 }

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -16,13 +16,18 @@ var patch = require("dom-patch");
 exports.ready = function(render){
 	var initial = handlers.initial;
 	handlers.initial = function(){
-		initial.apply(this, arguments);
+		var afterPatch = initial.apply(this, arguments);
 
 		// Listen for changes in the document and call postMessage
 		// with the patches that will be applied on the other side.
 		patch(document, function(patches){
 			postMessage(patches);
 		});
+
+		// initial returns a function that will patch back in elements
+		// that were inserted before the initial HTML had been rendered
+		// in the worker DOM.
+		afterPatch();
 
 		// Call the initial render
 		render();

--- a/test/basics/basics.js
+++ b/test/basics/basics.js
@@ -1,0 +1,11 @@
+var workerRender = require("worker-render/worker");
+var $ = require("jquery");
+require("./style.css!");
+
+workerRender.ready(render);
+
+function render(){
+	var span = document.createElement("span");
+	span.appendChild(document.createTextNode("Hello world!"));
+	$("body").html(span);
+}

--- a/test/basics/index.html
+++ b/test/basics/index.html
@@ -1,0 +1,6 @@
+<script src="../../node_modules/steal/steal.js">
+	var worker = new Worker(System.stealURL+"?main=test/basics/basics");
+
+	var windowRender = require("worker-render/window");
+	windowRender.updateWith(worker);
+</script>

--- a/test/basics/style.css
+++ b/test/basics/style.css
@@ -1,0 +1,3 @@
+body {
+	background: blue;
+}

--- a/test/test.js
+++ b/test/test.js
@@ -5,7 +5,18 @@ QUnit.config.testTimeout = 30000;
 
 F.attach(QUnit);
 
-QUnit.module("worker-render", {
+QUnit.module("worker-render basics", {
+	setup: function(){
+		F.open("//basics/index.html");
+	}
+});
+
+QUnit.test("renders an element with css", function(){
+	F("span").exists().text(/Hello world/, "span rendered correctly");
+	F("style").exists("style tag added to the window DOM");
+});
+
+QUnit.module("worker-render events", {
 	setup: function(){
 		F.open("//../demo/simple_event.html");
 	}


### PR DESCRIPTION
When the page first loads we send the original HTML over to the worker
side to serve as the initial state. However more things might have
loaded in the mean time, usually css, so we need to preserve those items
in the head after the initial render.

<img width="479" alt="screen shot 2015-07-21 at 8 26 52 am" src="https://cloud.githubusercontent.com/assets/361671/8800634/7285caf4-2f82-11e5-8e0b-99f4981ac775.png">
